### PR TITLE
Persist scaler with model

### DIFF
--- a/lab_order_time_series.py
+++ b/lab_order_time_series.py
@@ -1,10 +1,11 @@
 import os
 from datetime import datetime
-from typing import List
+from typing import List, Tuple
 
 import pandas as pd
 from darts import TimeSeries
 from darts.dataprocessing.transformers import Scaler
+import pickle
 from darts.models import TFTModel
 from pytorch_lightning.loggers import TensorBoardLogger
 
@@ -18,6 +19,7 @@ LOG_DIR = "logs"
 PLOTS_DIR = "plots"
 MODEL_FILE = os.path.join(MODEL_DIR, "tft_model.pth")
 PARAMS_FILE = os.path.join(MODEL_DIR, "tft_model_params.json")
+SCALER_FILE = os.path.join(MODEL_DIR, "scaler.pkl")
 
 GROUP_COLS = ["status", "is_droplet"]
 METRICS = ["placed_gmv", "delivered_gmv", "cancelled_gmv"]
@@ -65,31 +67,47 @@ def create_model(logger: TensorBoardLogger) -> TFTModel:
     return TFTModel(log_tensorboard=True, tensorboard_logger=logger, **MODEL_PARAMS)
 
 
-def train_model(series_list: List[TimeSeries]) -> TFTModel:
+def train_model(series_list: List[TimeSeries]) -> Tuple[TFTModel, Scaler]:
+    """Train the TFT model and return it along with a fitted scaler."""
     ensure_dirs()
     logger = TensorBoardLogger(LOG_DIR, name="tft")
 
-    if os.path.exists(MODEL_FILE):
+    if os.path.exists(MODEL_FILE) and os.path.exists(SCALER_FILE):
         model = TFTModel.load(MODEL_FILE)
+        with open(SCALER_FILE, "rb") as f:
+            scaler = pickle.load(f)
     else:
         model = create_model(logger)
         scaler = Scaler()
         series_scaled = [scaler.fit_transform(s) for s in series_list]
         model.fit(series_scaled, verbose=True)
         model.save(MODEL_FILE)
+        with open(SCALER_FILE, "wb") as f:
+            pickle.dump(scaler, f)
         with open(PARAMS_FILE, "w") as f:
             import json
             json.dump(MODEL_PARAMS, f, indent=2)
-    return model
+    return model, scaler
 
 
-def forecast_and_plot(model: TFTModel, series_list: List[TimeSeries], horizon: int = 7):
+def forecast_and_plot(
+    model: TFTModel,
+    series_list: List[TimeSeries],
+    scaler: Scaler | None = None,
+    horizon: int = 7,
+):
+    """Use the trained model and scaler to forecast and save plots."""
+    if scaler is None:
+        if os.path.exists(SCALER_FILE):
+            with open(SCALER_FILE, "rb") as f:
+                scaler = pickle.load(f)
+        else:
+            scaler = Scaler()
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     plot_dir = os.path.join(PLOTS_DIR, timestamp)
     os.makedirs(plot_dir, exist_ok=True)
 
-    scaler = Scaler()
-    scaled_series = [scaler.fit_transform(s) for s in series_list]
+    scaled_series = [scaler.transform(s) for s in series_list]
     forecasts = [model.predict(horizon, s) for s in scaled_series]
 
     for i, (orig, pred) in enumerate(zip(series_list, forecasts)):
@@ -106,12 +124,25 @@ def forecast_and_plot(model: TFTModel, series_list: List[TimeSeries], horizon: i
 
 import numpy as np
 
-def backtest_and_save(model: TFTModel, series_list: List[TimeSeries], test_fraction: float = 0.2, z_thresh: float = 3.0):
+def backtest_and_save(
+    model: TFTModel,
+    series_list: List[TimeSeries],
+    scaler: Scaler | None = None,
+    test_fraction: float = 0.2,
+    z_thresh: float = 3.0,
+):
+    """Backtest the model using the provided scaler and save any anomalies."""
+    if scaler is None:
+        if os.path.exists(SCALER_FILE):
+            with open(SCALER_FILE, "rb") as f:
+                scaler = pickle.load(f)
+        else:
+            scaler = Scaler()
+
     anomalies = []
-    scaler = Scaler()
 
     for idx, series in enumerate(series_list):
-        series = scaler.fit_transform(series)
+        series = scaler.transform(series)
         train, val = series.split_before(1 - test_fraction)
         model.fit([train], verbose=False)
         pred = model.predict(len(val), train)
@@ -130,9 +161,9 @@ def backtest_and_save(model: TFTModel, series_list: List[TimeSeries], test_fract
 
 def main():
     series_list = load_series()
-    model = train_model(series_list)
-    forecast_and_plot(model, series_list)
-    backtest_and_save(model, series_list)
+    model, scaler = train_model(series_list)
+    forecast_and_plot(model, series_list, scaler)
+    backtest_and_save(model, series_list, scaler)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- save fitted scaler when training the TFT model
- return the scaler from `train_model`
- load or reuse the scaler in `forecast_and_plot` and `backtest_and_save`
- update `main` to pass the scaler

## Testing
- `python -m py_compile lab_order_time_series.py`

------
https://chatgpt.com/codex/tasks/task_e_683fadf3e0008328a7d1d686a0b2274b